### PR TITLE
user一覧を五十音順に表示する #20

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name)
+    params.require(:user).permit(:name, :furigana)
   end
 
   def set_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[show edit update destroy]
   def index
-    @users = User.all
+    @users = User.all.order(:furigana)
   end
 
   def show; end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@
 class User < ApplicationRecord
   validates :name, presence: true
   validates :name, length: { maximum: 30 }
+  validates :furigana, presence: true
+  validates :furigana, length: { maximum: 30 }
 end

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -7,4 +7,6 @@
     .mb-3
       = f.label :name
       = f.text_field :name, class: 'form-control', id: 'name'
+      = f.label :furigana
+      = f.text_field :furigana, class: 'form-control', id: 'furigana'
     = f.submit nil, class: 'btn btn-primary'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,6 +17,7 @@ ja:
       user:
         id: ID
         name: 名前
+        furigana: フリガナ
   date:
     abbr_day_names:
       - 日

--- a/db/migrate/20220127053645_add_furigana_to_users.rb
+++ b/db/migrate/20220127053645_add_furigana_to_users.rb
@@ -1,0 +1,5 @@
+class AddFuriganaToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :furigana, :string
+  end
+end

--- a/db/migrate/20220127054524_change_users_furigana_not_null.rb
+++ b/db/migrate/20220127054524_change_users_furigana_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeUsersFuriganaNotNull < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :users, :furigana, false
+  end
+end

--- a/db/migrate/20220127054708_change_users_furigana_limit30.rb
+++ b/db/migrate/20220127054708_change_users_furigana_limit30.rb
@@ -1,0 +1,9 @@
+class ChangeUsersFuriganaLimit30 < ActiveRecord::Migration[6.1]
+  def up
+    change_column :users, :furigana, :string, limit: 30
+  end
+
+  def down
+    change_column :users, :furigana, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_27_042633) do
+ActiveRecord::Schema.define(version: 2022_01_27_054708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2022_01_27_042633) do
     t.string "name", limit: 30, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "furigana", limit: 30, null: false
   end
 
 end


### PR DESCRIPTION
## 目的
user一覧を五十音順に表示する
## 変更点
- データベースにふりがなを追加
- ふりがなの翻訳情報を追加
- ふりがな情報をpermitに追加
- user登録にふりがな入力フォームを追加
<img width="1440" alt="スクリーンショット 2022-01-27 15 14 24" src="https://user-images.githubusercontent.com/95733683/151302264-4091a58f-f77c-44f2-8a38-51a6ca1ff204.png">

- ふりがなに検証を追加
- user一覧をふりがなの五十音順で表示する
<img width="1440" alt="スクリーンショット 2022-01-27 15 14 49" src="https://user-images.githubusercontent.com/95733683/151302309-6ca61fff-feee-4f8e-8976-a9dc1b5dcd1a.png">

## 注意点
名前を五十音で表示するためにフリガナを登録できるようにしました。

close #20