### PR TITLE
貸し出し（登録）機能を実装する #22

### DIFF
--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -3,11 +3,24 @@
 class RentalsController < ApplicationController
   def index; end
 
-  def new; end
+  def new
+    @rental = Renatl.new
+  end
 
   def edit; end
 
-  def create; end
+  def create
+    @book = Book.find(params[:book_id])
+    @rental = Rental.new(rental_params)
+    @rental.save!
+    redirect_to books_url, notice: "書籍「#{@book.title}」をレンタルしました。"
+  end
 
   def update; end
+
+  private
+
+  def rental_params
+    params.permit(:user_id, :book_id)
+  end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -6,5 +6,5 @@ class Book < ApplicationRecord
   validates :title, presence: true
   validates :title, length: { maximum: 30 }
 
-  has_many :rentals
+  has_many :rentals, dependent: :nullify
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,5 @@ class User < ApplicationRecord
   validates :furigana, presence: true
   validates :furigana, length: { maximum: 30 }
 
-  has_many :rentals
+  has_many :rentals, dependent: :nullify
 end

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -1,4 +1,8 @@
 h1= @book.title
 
+= form_with url: rentals_path(book_id: @book.id), method: :post do |f|
+  = f.collection_select(:user_id, User.order(:furigana), :id, :name, {prompt: '選択してください'}, {class: 'form-control input-sm mb-3'})
+  = f.submit '借りる', class: 'btn btn-primary mb-3'
+
 = link_to '編集', edit_book_path, class: 'btn btn-primary me-3'
 = link_to '削除', @book, method: :delete, data: { confirm: "書籍「#{@book.title}」を削除します。よろしいですか？"}, class: 'btn btn-danger'

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -1,7 +1,7 @@
 h1= @book.title
 
 = form_with url: rentals_path(book_id: @book.id), method: :post do |f|
-  = f.collection_select(:user_id, User.order(:furigana), :id, :name, {prompt: '選択してください'}, {class: 'form-control input-sm mb-3'})
+  = f.collection_select(:user_id, User.order(:furigana), :id, :name, {prompt: '借りる人を選択してください'}, {class: 'form-control input-sm mb-3'})
   = f.submit '借りる', class: 'btn btn-primary mb-3'
 
 = link_to '編集', edit_book_path, class: 'btn btn-primary me-3'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
     models:
       book: 書籍
       user: 社員
+      rental: 貸し出し
     attributes:
       book:
         id: ID
@@ -18,6 +19,10 @@ ja:
         id: ID
         name: 名前
         furigana: フリガナ
+      rental:
+        id: ID
+        created_at: 貸し出し日
+        updated_at: 返却日
   date:
     abbr_day_names:
       - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   root to: 'books#index'
   resources :books
   resources :users
+  resources :rentals
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 目的
貸し出し（登録）機能を実装する
## 変更点
- dependentオプションを追加
- rentalモデルの翻訳情報を追加
- ルーティングの設定
- 貸し出し機能を実装する
- 貸し出し機能のビューを追加する

<img width="1440" alt="スクリーンショット 2022-01-31 10 49 01" src="https://user-images.githubusercontent.com/95733683/151728731-3c0bd292-7289-4f64-b3ea-94ff42e2523f.png">

<img width="1440" alt="スクリーンショット 2022-01-31 10 52 03" src="https://user-images.githubusercontent.com/95733683/151728637-a680b1d9-4d82-481b-b0ea-e5e361fe8d48.png">

## 注意点
- dependentオプションを追加
- rentalモデルの翻訳情報を追加
- ルーティングの設定
はIssue21で行う内容でしたが、抜けていたのでここで追加しました

close #22 