### PR TITLE
user詳細に貸し出し一覧機能のビューを実装する

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -2,3 +2,16 @@ h1= @user.name
 
 = link_to '編集', edit_user_path, class: 'btn btn-primary me-3'
 = link_to '削除', @user, method: :delete, data: { confirm: "「#{@user.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger'
+
+h2.mt-3 貸し出し履歴
+
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= Book.human_attribute_name(:title)
+      th= Rental.human_attribute_name(:created_at)
+  tbody
+    - @user.rentals.each do |rental|
+      tr
+        td= link_to rental.book.title, book_path
+        td= I18n.l(rental.created_at)


### PR DESCRIPTION
## 目的
user詳細に貸し出し一覧機能のビューを実装する
## 変更点
- user詳細に貸し出し一覧機能のビューを実装する
<img width="1440" alt="スクリーンショット 2022-02-01 10 36 25" src="https://user-images.githubusercontent.com/95733683/151900511-e0920cbf-ad91-4b74-ae1f-087c29e7bd82.png">

## 注意点
user一覧スケッチ
https://luxiar.slack.com/files/U02P3G7QT5Z/F02UNCJ2E57/________________________.pdf?origin_team=T01R0Q49N94&origin_channel=D02PT782JPJ

close #24 