### PR TITLE
貸し出し一覧を貸し出し日の新しい順に表示する #27, 28

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -8,7 +8,9 @@ class BooksController < ApplicationController
     @books = @q.result.order(:title)
   end
 
-  def show; end
+  def show
+    @rentals = @book.rentals.order(created_at: :desc)
+  end
 
   def new
     @book = Book.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,9 @@ class UsersController < ApplicationController
     @users = User.all.order(:furigana)
   end
 
-  def show; end
+  def show
+    @rentals = @user.rentals.order(created_at: :desc)
+  end
 
   def new
     @user = User.new

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -26,7 +26,7 @@ table.table.table-hover
       th= Rental.human_attribute_name(:created_at)
       th= Rental.human_attribute_name(:returned_at)
   tbody
-    - @book.rentals.each do |rental|
+    - @book.rentals.order(created_at: :desc).each do |rental|
       tr
         td= link_to rental.user.name, user_path(rental.user)
         td= I18n.l(rental.created_at)

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -26,7 +26,7 @@ table.table.table-hover
       th= Rental.human_attribute_name(:created_at)
       th= Rental.human_attribute_name(:returned_at)
   tbody
-    - @book.rentals.order(created_at: :desc).each do |rental|
+    - @rentals.each do |rental|
       tr
         td= link_to rental.user.name, user_path(rental.user)
         td= I18n.l(rental.created_at)

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -12,7 +12,7 @@ table.table.table-hover
       th= Rental.human_attribute_name(:created_at)
       th= Rental.human_attribute_name(:returned_at)
   tbody
-    - @user.rentals.each do |rental|
+    - @user.rentals.order(created_at: :desc).each do |rental|
       tr
         td= link_to rental.book.title, book_path
         td= I18n.l(rental.created_at)

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -14,7 +14,7 @@ table.table.table-hover
   tbody
     - @user.rentals.order(created_at: :desc).each do |rental|
       tr
-        td= link_to rental.book.title, book_path
+        td= link_to rental.book.title, book_path(rental.book)
         td= I18n.l(rental.created_at)
         - if rental.going?
           td= '貸し出し中'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -12,7 +12,7 @@ table.table.table-hover
       th= Rental.human_attribute_name(:created_at)
       th= Rental.human_attribute_name(:returned_at)
   tbody
-    - @user.rentals.order(created_at: :desc).each do |rental|
+    - @rentals.each do |rental|
       tr
         td= link_to rental.book.title, book_path(rental.book)
         td= I18n.l(rental.created_at)


### PR DESCRIPTION
## 目的
貸し出し一覧を貸し出し日の新しい順に表示する 
## 変更点
- book詳細の貸し出し一覧を新しい順にする。
<img width="1435" alt="スクリーンショット 2022-02-04 16 33 21" src="https://user-images.githubusercontent.com/95733683/152489686-7fcd5f0c-d2f2-4d77-86f8-931ba84ab74a.png">

- user詳細の貸し出し一覧を新しい順にする。
<img width="1440" alt="スクリーンショット 2022-02-04 16 33 01" src="https://user-images.githubusercontent.com/95733683/152489626-3dd38934-e4bf-4586-99bb-12aefa08169e.png">

- user詳細画面のbookリンクを修正
## 注意点
- user詳細画面のbookリンクを修正
どのリンクを押してもbook_idが1の本に飛んでしまっていたので修正しました。

close #27
close #28 