### PR TITLE
フォームを整える #67

### DIFF
--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -6,5 +6,7 @@
 = form_with model: book, local: true do |f|
     .mb-3
       = f.label :title
-      = f.text_field :title, class: 'form-control', id: 'title'
+      .row
+        .col-6
+          = f.text_field :title, class: 'form-control', id: 'title'
     = f.submit nil, class: 'btn btn-primary'

--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -8,5 +8,5 @@
       = f.label :title
       .row
         .col-6
-          = f.text_field :title, class: 'form-control', id: 'title'
+          = f.text_field :title, class: 'form-control', id: 'title', placeholder: '書籍のタイトルを入力してください'
     = f.submit nil, class: 'btn btn-primary'

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,7 +1,7 @@
 h1 書籍一覧
 
 
-= search_form_for @q, class: 'mb-5' do |f|
+= search_form_for @q, class: 'mb-3' do |f|
   = f.label :title_cont, '書籍検索', class: 'col-sm-2 col-form-label'
   .row
     .col-6

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -2,10 +2,10 @@ h1 書籍一覧
 
 
 = search_form_for @q, class: 'mb-5' do |f|
-  = f.label :title_cont, 'タイトル', class: 'col-sm-2 col-form-label'
+  = f.label :title_cont, '書籍検索', class: 'col-sm-2 col-form-label'
   .row
     .col-6
-      = f.search_field :title_cont, class: 'form-control'
+      = f.search_field :title_cont, class: 'form-control', placeholder: '書籍のタイトルを入力してください'
     .col-1
       = f.submit class: 'btn btn-primary'
 

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -8,7 +8,7 @@
       = f.label :name
       .row
         .col-6
-          = f.text_field :name, class: 'form-control', id: 'name', placeholder: '社員名を入力してください'
+          = f.text_field :name, class: 'form-control mb-3', id: 'name', placeholder: '社員名を入力してください'
       = f.label :furigana
       .row
         .col-6

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -8,9 +8,9 @@
       = f.label :name
       .row
         .col-6
-          = f.text_field :name, class: 'form-control', id: 'name'
+          = f.text_field :name, class: 'form-control', id: 'name', placeholder: '社員名を入力してください'
       = f.label :furigana
       .row
         .col-6
-          = f.text_field :furigana, class: 'form-control', id: 'furigana'
+          = f.text_field :furigana, class: 'form-control', id: 'furigana', placeholder: 'フリガナをカタカナで入力してください'
     = f.submit nil, class: 'btn btn-primary'

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -6,7 +6,11 @@
 = form_with model: user, local: true do |f|
     .mb-3
       = f.label :name
-      = f.text_field :name, class: 'form-control', id: 'name'
+      .row
+        .col-6
+          = f.text_field :name, class: 'form-control', id: 'name'
       = f.label :furigana
-      = f.text_field :furigana, class: 'form-control', id: 'furigana'
+      .row
+        .col-6
+          = f.text_field :furigana, class: 'form-control', id: 'furigana'
     = f.submit nil, class: 'btn btn-primary'

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,3 +1,3 @@
-h1 社員登録の編集
+h1 社員情報の編集
 
 = render partial: 'form', locals: { user: @user }


### PR DESCRIPTION
## 目的
フォームを整える 
## 変更点

1. 入力フォームの大きさを調整する

→userの名前、ふりがな、bookのタイトルの入力フォームが長いので調節する

2.  プレースホルダーを使う

→userの名前、ふりがな、bookのタイトルの入力フォーム、検索フォームにプレースホルダーを使い、なんのフォームなのかわかりやすくする

3. マージンの調整

book_new→1. 2. 
<img width="1440" alt="スクリーンショット 2022-02-09 13 02 46" src="https://user-images.githubusercontent.com/95733683/153119682-39393175-6a65-458f-a511-a3f47723ca16.png">
user_new→1. 2. 3
<img width="1440" alt="スクリーンショット 2022-02-09 13 03 46" src="https://user-images.githubusercontent.com/95733683/153119743-3a954eb7-2e71-4777-a77a-d00d9458cad5.png">
book_index→2. 3.
<img width="1440" alt="スクリーンショット 2022-02-09 13 04 12" src="https://user-images.githubusercontent.com/95733683/153119783-f1e308ac-eb4c-4b0d-b867-0a5408d79557.png">

## 注意点
close #67