### PR TITLE
エラー、フラッシュメッセージを整える #68

### DIFF
--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -1,7 +1,7 @@
 - if book.errors.present?
-  #error_explanation.alert.alert-danger
+  ul#error_explanation.alert.alert-danger [style=" list-style: none;"]
     - book.errors.full_messages.each do |message|
-      = message
+      li= message
 
 = form_with model: book, local: true do |f|
     .mb-3

--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -1,7 +1,7 @@
 - if book.errors.present?
-  ul#error_explanation
+  #error_explanation.alert.alert-danger
     - book.errors.full_messages.each do |message|
-      li= message
+      .= message
 
 = form_with model: book, local: true do |f|
     .mb-3

--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -1,7 +1,7 @@
 - if book.errors.present?
   #error_explanation.alert.alert-danger
     - book.errors.full_messages.each do |message|
-      .= message
+      = message
 
 = form_with model: book, local: true do |f|
     .mb-3

--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -1,5 +1,5 @@
 - if book.errors.present?
-  ul#error_explanation.alert.alert-danger [style=" list-style: none;"]
+  ul#error_explanation.alert.alert-danger [style="list-style: none;"]
     - book.errors.full_messages.each do |message|
       li= message
 

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -2,9 +2,6 @@
   h1.float-start = @book.title
   = link_to '編集', edit_book_path(@book), class: 'btn btn-link btn-lg ms-4'
 
-- if flash.alert.present?
-  .alert.alert-danger= flash.alert
-
 - if @rental&.errors.present?
   ul#error_explanation.alert.alert-danger [style="list-style: none;"]
     - @rental.errors.full_messages.each do |message|

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -8,7 +8,7 @@
 - if @rental&.errors.present?
   #error_explanation.alert.alert-danger
     - @rental.errors.full_messages.each do |message|
-      .= message
+      = message
 
 - unless @book.going_rental
   = form_with url: rentals_path(book_id: @book.id), method: :post do |f|

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -3,9 +3,9 @@
   = link_to '編集', edit_book_path(@book), class: 'btn btn-link btn-lg ms-4'
 
 - if @rental&.errors.present?
-  ul#error_explanation
+  #error_explanation.alert.alert-danger
     - @rental.errors.full_messages.each do |message|
-      li= message
+      .= message
 
 - unless @book.going_rental
   = form_with url: rentals_path(book_id: @book.id), method: :post do |f|

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -2,6 +2,9 @@
   h1.float-start = @book.title
   = link_to '編集', edit_book_path(@book), class: 'btn btn-link btn-lg ms-4'
 
+- if flash.alert.present?
+  .alert.alert-danger= flash.alert
+
 - if @rental&.errors.present?
   #error_explanation.alert.alert-danger
     - @rental.errors.full_messages.each do |message|

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -6,7 +6,7 @@
   .alert.alert-danger= flash.alert
 
 - if @rental&.errors.present?
-  ul#error_explanation.alert.alert-danger [style=" list-style: none;"]
+  ul#error_explanation.alert.alert-danger [style="list-style: none;"]
     - @rental.errors.full_messages.each do |message|
       li= message
 

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -6,9 +6,9 @@
   .alert.alert-danger= flash.alert
 
 - if @rental&.errors.present?
-  #error_explanation.alert.alert-danger
+  ul#error_explanation.alert.alert-danger [style=" list-style: none;"]
     - @rental.errors.full_messages.each do |message|
-      = message
+      li= message
 
 - unless @book.going_rental
   = form_with url: rentals_path(book_id: @book.id), method: :post do |f|

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,6 +26,4 @@ html
     .container.px-4
       -if flash.notice.present?
         .alert.alert-success= flash.notice
-      - if flash.alert.present?
-        .alert.alert-danger= flash.alert
       = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,4 +26,6 @@ html
     .container.px-4
       -if flash.notice.present?
         .alert.alert-success= flash.notice
+      - if flash.alert.present?
+        .alert.alert-danger= flash.alert
       = yield

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,7 +1,7 @@
 - if user.errors.present?
   #error_explanation.alert.alert-danger
     - user.errors.full_messages.each do |message|
-      .= message
+      div= message
 
 = form_with model: user, local: true do |f|
     .mb-3

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,7 +1,7 @@
 - if user.errors.present?
-  ul#error_explanation
+  #error_explanation.alert.alert-danger
     - user.errors.full_messages.each do |message|
-      li= message
+      .= message
 
 = form_with model: user, local: true do |f|
     .mb-3

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,5 +1,5 @@
 - if user.errors.present?
-  ul#error_explanation.alert.alert-danger [style=" list-style: none;"]
+  ul#error_explanation.alert.alert-danger [style="list-style: none;"]
     - user.errors.full_messages.each do |message|
       li= message
 

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,7 +1,7 @@
 - if user.errors.present?
-  #error_explanation.alert.alert-danger
+  ul#error_explanation.alert.alert-danger [style=" list-style: none;"]
     - user.errors.full_messages.each do |message|
-      div= message
+      li= message
 
 = form_with model: user, local: true do |f|
     .mb-3


### PR DESCRIPTION
## 目的
バリデーションエラーとflash.alertのメッセージの出方が違うので統一する
画面タイトル（h1）の下に表示、
alert alert-dangerを使う
## 変更点
- バリデーションエラーのメッセージの出方を変更
<img width="1440" alt="スクリーンショット 2022-02-09 14 42 27" src="https://user-images.githubusercontent.com/95733683/153129088-3ec1b38d-e54a-4b70-a9d9-4c64489bdfe2.png">

- フラッシュアラートを移動
## 注意点
- フラッシュアラートを移動
→フラッシュアラートはbook.showでしか出てこないので移動しました。

close #68