### PR TITLE
updateアクションをバリデーションエラーに対応させる

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -34,8 +34,11 @@ class BooksController < ApplicationController
   end
 
   def update
-    @book.update!(book_params)
-    redirect_to books_url, notice: "書籍「#{@book.title}」の登録情報を更新しました。"
+    if @book.update(book_params)
+      redirect_to @book, notice: "書籍「#{@book.title}」の登録情報を更新しました。"
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,8 +32,11 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user.update!(user_params)
-    redirect_to users_url, notice: "「#{@user.name}」の登録情報を更新しました。"
+    if @user.update(user_params)
+      redirect_to @user, notice: "「#{@user.name}」の登録情報を更新しました。"
+    else
+      render :edit
+    end
   end
 
   private


### PR DESCRIPTION
## 目的
[ユーザーの名前、ふりがなを空にして更新するとRailsのエラー画面が表示される #71](https://github.com/takuya-ookuchi/books-manager/issues/71)
[書籍の名前を空にして更新するとRailsのエラー画面が表示される #72](https://github.com/takuya-ookuchi/books-manager/issues/72)
を修正
## 変更点
- book/updateアクションをバリデーションに対応するよう変更
<img width="1440" alt="スクリーンショット 2022-02-10 10 44 57" src="https://user-images.githubusercontent.com/95733683/153321139-de05f139-167e-4dc9-87aa-4ee12ebdf325.png">

- user/updateアクションをバリデーションに対応するよう変更
<img width="1439" alt="スクリーンショット 2022-02-10 10 45 40" src="https://user-images.githubusercontent.com/95733683/153321205-cccf055c-006c-49b9-925e-af0967cb16c8.png">

## 注意点
#71 と#72 は同じ作業内容なのでP Rをまとめました。
リダイレクト先を一覧画面から詳細画面に変更しました。

close #71 
close #72 