### PR TITLE
借りる人を選ばずに借りるボタンを押すとRailsのエラー画面が表示される #73

### DIFF
--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -16,6 +16,7 @@ class RentalsController < ApplicationController
     if @rental.save
       redirect_to @book, notice: "書籍「#{@book.title}」をレンタルしました。"
     else
+      @rentals = @book.rentals.order(created_at: :desc)
       render template: 'books/show'
     end
   end


### PR DESCRIPTION
## 目的
[借りる人を選ばずに借りるボタンを押すとRailsのエラー画面が表示される](https://github.com/takuya-ookuchi/books-manager/issues/73)
## 変更点
- rentalモデルのcreateアクションが失敗したときに起こる エラーの修正
→rentalモデルで`@rentals`が定義されていなかったので、createアクションが失敗してレンダリングされたときに
`undefined method 'each' for nil:NilClass`というエラーが発生していました。
<img width="1086" alt="スクリーンショット 2022-02-10 14 57 47" src="https://user-images.githubusercontent.com/95733683/153346997-f60579c8-3e9a-4520-b9cf-431918eb1b98.png">

## 注意点

close #73 