### PR TITLE
ヘッダーの書籍一覧のリンクをなくしたい #81 

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,7 +11,7 @@ html
   body
     .app-title.navbar.navbar-expand-sm.navbar-dark.bg-dark.mb-5
       .container.px-4
-        .navbar-brand Booksmanager
+        = link_to 'Booksmanager', books_path, class: 'navbar-brand'
         .collapse.navbar-collapse
           ul.navbar-nav.me-auto.mb-2.mb-sm-0
             li.nav-item

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,8 +15,6 @@ html
         .collapse.navbar-collapse
           ul.navbar-nav.me-auto.mb-2.mb-sm-0
             li.nav-item
-              = link_to '書籍一覧', books_path, class: 'nav-link'
-            li.nav-item
               = link_to '書籍登録', new_book_path, class: 'nav-link'
             li.nav-item
               = link_to '社員一覧', users_path, class: 'nav-link'


### PR DESCRIPTION
## 目的
トップページが書籍一覧なのに、ヘッダーの一番最初のリンククリックでトップに移動するというのが違和感なので修正する
## 変更点
- ヘッダーの「Book Manager」をクリックしたら書籍一覧に飛ぶ
- 書籍一覧のリンクは無くす
<img width="1440" alt="スクリーンショット 2022-02-14 10 32 36" src="https://user-images.githubusercontent.com/95733683/153785597-32c32061-0f2a-4ea1-8dad-c26519fd8a98.png">

## 注意点
特になし

close #81 