### PR TITLE
社員はテーブルから削除せず、「退職フラグ」のようなカラムによって退職状態を表現することにする。 #78

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[show edit update destroy]
+  before_action :set_user, only: %i[show edit update update_in_office destroy]
   def index
     @users = User.all.order(:furigana)
   end
@@ -33,6 +33,14 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
+      redirect_to @user, notice: "「#{@user.name}」の登録情報を更新しました。"
+    else
+      render :edit
+    end
+  end
+
+  def update_in_office
+    if @user.update(params.permit(:in_office))
       redirect_to @user, notice: "「#{@user.name}」の登録情報を更新しました。"
     else
       render :edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,7 +42,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :furigana)
+    params.permit(:name, :furigana, :in_office)
   end
 
   def set_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,7 +42,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.permit(:name, :furigana, :in_office)
+    params.require(:user).permit(:name, :furigana)
   end
 
   def set_user

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -11,7 +11,7 @@
   = form_with url: rentals_path(book_id: @book.id), method: :post do |f|
     .row
       .col-6
-        = f.collection_select(:user_id, User.order(:furigana), :id, :name, {prompt: '借りる人を選択してください'}, {class: 'form-control form-control-lg input-sm mb-3'})
+        = f.collection_select(:user_id, User.where(in_office: true).order(:furigana), :id, :name, {prompt: '借りる人を選択してください'}, {class: 'form-control form-control-lg input-sm mb-3'})
       .col-1
         = f.submit '借りる', class: 'btn btn-primary btn-lg mb-3'
 - else

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -3,7 +3,7 @@
     - user.errors.full_messages.each do |message|
       li= message
 
-= form_with model: user, method: user.persisted? ? 'PUT' : 'POST', local: true do |f|
+= form_with model: user, method: user.persisted? ? :put : :post, local: true do |f|
     .mb-3
       = f.label :name
       .row

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -3,7 +3,7 @@
     - user.errors.full_messages.each do |message|
       li= message
 
-= form_with model: user, local: true do |f|
+= form_with model: user, method: user.persisted? ? 'PUT' : 'POST', local: true do |f|
     .mb-3
       = f.label :name
       .row

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -13,3 +13,7 @@ table.table.table-hover
           td= link_to user.renting_book.title, book_path(user.renting_book)
         - else
           td
+        - unless user.in_office
+          td.text-danger= '退職済み'
+        - else
+          td

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -13,7 +13,7 @@ table.table.table-hover
           td= link_to user.renting_book.title, book_path(user.renting_book)
         - else
           td
-        - unless user.in_office
+        - unless user.in_office?
           td.text-danger= '退職済み'
         - else
           td

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -28,7 +28,7 @@ table.table.table-hover
         - else
           td= I18n.l(rental.returned_at)
 
-- if @user.in_office
+- if @user.in_office?
   = form_with url: user_path(in_office: false), method: :patch do |f|
     = f.submit '退職', class: 'btn btn-danger btn-lg col-3 my-5'
 - else

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -2,10 +2,11 @@
   h4.text-danger 退職済み
 
 .clearfix
-  - if @user.in_office
+  - if @user.in_office?
     h1.float-start= @user.name
   - else
     h1.float-start.text-secondary= @user.name
+
   = link_to '編集', edit_user_path(@user), class: 'btn btn-link btn-lg ms-4'
 
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,4 @@
-- unless  @user.in_office
+- unless @user.in_office
   h4.text-danger 退職済み
 
 .clearfix
@@ -24,7 +24,7 @@ table.table.table-hover
         td= I18n.l(rental.created_at)
         - if rental.going?
           td= '貸し出し中'
-        -else
+        - else
           td= I18n.l(rental.returned_at)
 
 - if @user.in_office

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -20,4 +20,9 @@ table.table.table-hover
         -else
           td= I18n.l(rental.returned_at)
 
-= link_to 'この社員を削除する', @user, method: :delete, data: { confirm: "「#{@user.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger btn-lg col-3 my-5'
+- if @user.in_office
+  = form_with url: user_path(in_office: false), method: :patch do |f|
+    = f.submit '退職', class: 'btn btn-danger btn-lg col-3 my-5'
+- else
+  = form_with url: user_path(in_office: true), method: :patch do |f|
+    = f.submit '復職', class: 'btn btn-success btn-lg col-3 my-5'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,7 +1,6 @@
 - unless  @user.in_office
   h4.text-danger 退職済み
 
-
 .clearfix
   - if @user.in_office
     h1.float-start= @user.name

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,5 +1,13 @@
-h1.float-start = @user.name
-= link_to '編集', edit_user_path(@user), class: 'btn btn-link btn-lg ms-4'
+- unless  @user.in_office
+  h4.text-danger 退職済み
+
+
+.clearfix
+  - if @user.in_office
+    h1.float-start= @user.name
+  - else
+    h1.float-start.text-secondary= @user.name
+  = link_to '編集', edit_user_path(@user), class: 'btn btn-link btn-lg ms-4'
 
 
 h2.mt-3 貸し出し履歴

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,15 @@
 Rails.application.routes.draw do
   root to: 'books#index'
   resources :books
-  resources :users
   resources :rentals
+
+  get '/users', to: 'users#index'
+  get '/users/new', to: 'users#new', as: 'new_user'
+  post '/users', to: 'users#create'
+  get '/users/:id', to: 'users#show', as: 'user'
+  get '/users/:id/edit', to: 'users#edit', as: 'edit_user'
+  put '/users/:id', to: 'users#update'
+  patch '/users/:id', to: 'users#update_in_office'
+  delete '/users/:id', to: 'users#destroy'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20220214044140_add_in_office_to_users.rb
+++ b/db/migrate/20220214044140_add_in_office_to_users.rb
@@ -1,0 +1,5 @@
+class AddInOfficeToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :in_office, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_01_044753) do
+ActiveRecord::Schema.define(version: 2022_02_14_044140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2022_02_01_044753) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "furigana", limit: 30, null: false
+    t.boolean "in_office", default: true, null: false
   end
 
   add_foreign_key "rentals", "books"


### PR DESCRIPTION
## 目的
社員はテーブルから削除せず、「退職フラグ」のようなカラムによって退職状態を表現することにする。
## 変更点
- dbにin_officeカラムを追加
- 変更　コントローラでin_officeカラムの追加に対応
- 変更　削除ボタン→退職、復職ボタン
<img width="1440" alt="スクリーンショット 2022-02-14 17 24 41" src="https://user-images.githubusercontent.com/95733683/153826817-da040c85-7351-451e-8e1b-97192468b338.png">
<img width="1417" alt="スクリーンショット 2022-02-14 17 25 08" src="https://user-images.githubusercontent.com/95733683/153826865-1d8d8cc1-afa6-4983-bf16-db3db171ee4d.png">

- user一覧に退職済み欄を追加
<img width="1440" alt="スクリーンショット 2022-02-14 17 25 29" src="https://user-images.githubusercontent.com/95733683/153826907-4a538352-d553-49f8-8487-c6dee50296e1.png">

- 変更　セレクトボックスに退職済みを表示しない
↓大口が退職になっているので表示されていない
<img width="866" alt="スクリーンショット 2022-02-14 17 26 09" src="https://user-images.githubusercontent.com/95733683/153827051-7f5d7d16-4a99-48a8-848c-84a9eb33a715.png">

- 変更　user詳細に退職済みを表示、名前をグレーに
<img width="1424" alt="スクリーンショット 2022-02-14 17 24 16" src="https://user-images.githubusercontent.com/95733683/153826751-a1944170-d9ae-4e7a-914d-11b1648d4e93.png">



## 注意点
- 在職中はわざわざ表示する必要がないと思ったので、退職済みのみ表示しています
- user一覧のリンクもuser詳細に合わせてグレーにした方がいいですか？

close #78 