### PR TITLE
書籍の画像を登録できるようにする #89

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
       hpricot
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -110,6 +113,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.4.2)
@@ -188,6 +192,8 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -258,6 +264,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   html2slim
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -44,7 +44,7 @@ class BooksController < ApplicationController
   private
 
   def book_params
-    params.require(:book).permit(:title)
+    params.require(:book).permit(:title, :image)
   end
 
   def set_book

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -5,6 +5,7 @@ class Book < ApplicationRecord
   # 同じ本が２冊以上ある場合、１冊づつ別々で登録するためユニーク制約は設定しない
   validates :title, presence: true
   validates :title, length: { maximum: 30 }
+  validate :validate_image
 
   has_many :rentals, dependent: :destroy
   has_one_attached :image
@@ -15,5 +16,23 @@ class Book < ApplicationRecord
 
   def current_borrower
     going_rental.user
+  end
+
+  def validate_image
+    return unless image.attached?
+    if image.blob.byte_size > 10.megabytes
+      image = nil
+      errors.add(:image, 'ファイルのサイズが大きすぎます')
+    elsif !image?
+      image = nil
+      errors.add(:image, 'ファイルが対応している画像データではありません')
+    end
+    image
+  end
+
+  private
+
+  def image?
+    %w[image/jpg image/jpeg image/gif image/png].include?(image.blob.content_type)
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -7,6 +7,7 @@ class Book < ApplicationRecord
   validates :title, length: { maximum: 30 }
 
   has_many :rentals, dependent: :destroy
+  has_one_attached :image
 
   def going_rental
     rentals.where(returned_at: nil).first

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -21,13 +21,12 @@ class Book < ApplicationRecord
   def validate_image
     return unless image.attached?
     if image.blob.byte_size > 10.megabytes
-      image = nil
+      self.image = nil
       errors.add(:image, 'ファイルのサイズが大きすぎます')
     elsif !image?
-      image = nil
+      self.image = nil
       errors.add(:image, 'ファイルが対応している画像データではありません')
     end
-    image
   end
 
   private

--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -9,4 +9,8 @@
       .row
         .col-6
           = f.text_field :title, class: 'form-control', id: 'title', placeholder: '書籍のタイトルを入力してください'
+      = f.label :image
+      .row
+        .col-6
+          = f.file_field :image, class: 'form-control'
     = f.submit nil, class: 'btn btn-primary'

--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -8,7 +8,7 @@
       = f.label :title
       .row
         .col-6
-          = f.text_field :title, class: 'form-control', id: 'title', placeholder: '書籍のタイトルを入力してください'
+          = f.text_field :title, class: 'form-control mb-3', id: 'title', placeholder: '書籍のタイトルを入力してください'
       = f.label :image
       .row
         .col-6

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -1,16 +1,16 @@
+.clearfix.mb-3
+  svg.bi.bi-book.float-start.me-3[xmlns="http://www.w3.org/2000/svg" width="50" height="50" fill="currentColor" viewbox="0 0 16 16"]
+    path[d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811V2.828zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"]
+  h1.float-start = @book.title
+  = link_to '編集', edit_book_path(@book), class: 'btn btn-link btn-lg ms-4'
+
 .row
   .col-2
     - if @book.image.attached?
-      image= image_tag @book.image.variant(resize:'364x257').processed, class: 'img-thumbnail float-start'
+      image= image_tag @book.image.variant(resize:'257x364').processed, class: 'img-thumbnail float-start'
     - else
       img.img-thumbnail[src="https://placehold.jp/257x364.png?text=book image" alt="..."]
   .col-10
-    .clearfix.mb-3
-      svg.bi.bi-book.float-start.me-3[xmlns="http://www.w3.org/2000/svg" width="50" height="50" fill="currentColor" viewbox="0 0 16 16"]
-        path[d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811V2.828zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"]
-      h1.float-start = @book.title
-      = link_to '編集', edit_book_path(@book), class: 'btn btn-link btn-lg ms-4'
-
     - if @rental&.errors.present?
       ul#error_explanation.alert.alert-danger [style="list-style: none;"]
         - @rental.errors.full_messages.each do |message|

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -7,9 +7,9 @@
 .row
   .col-2
     - if @book.image.attached?
-      = image_tag @book.image.variant(resize:'257x364').processed, class: 'img-thumbnail float-start'
+      = image_tag @book.image.variant(resize:'257x364').processed, class: 'img-thumbnail float-start', alt: '書籍の画像'
     - else
-      img.img-thumbnail[src="https://placehold.jp/257x364.png?text=book image" alt="..."]
+      img.img-thumbnail[src="https://placehold.jp/257x364.png?text=book image" alt="書籍の画像（未登録のため代替のプレースホルダー画像）"]
   .col-10
     - if @rental&.errors.present?
       ul#error_explanation.alert.alert-danger [style="list-style: none;"]

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -1,24 +1,31 @@
-.clearfix
-  svg.bi.bi-book.float-start.me-3[xmlns="http://www.w3.org/2000/svg" width="50" height="50" fill="currentColor" viewbox="0 0 16 16"]
-    path[d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811V2.828zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"]
-  h1.float-start = @book.title
-  = link_to '編集', edit_book_path(@book), class: 'btn btn-link btn-lg ms-4'
+.row
+  .col-2
+    - if @book.image.attached?
+      image= image_tag @book.image.variant(resize:'364x257').processed, class: 'img-thumbnail float-start'
+    - else
+      img.img-thumbnail[src="https://placehold.jp/257x364.png?text=book image" alt="..."]
+  .col-10
+    .clearfix.mb-3
+      svg.bi.bi-book.float-start.me-3[xmlns="http://www.w3.org/2000/svg" width="50" height="50" fill="currentColor" viewbox="0 0 16 16"]
+        path[d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811V2.828zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"]
+      h1.float-start = @book.title
+      = link_to '編集', edit_book_path(@book), class: 'btn btn-link btn-lg ms-4'
 
-- if @rental&.errors.present?
-  ul#error_explanation.alert.alert-danger [style="list-style: none;"]
-    - @rental.errors.full_messages.each do |message|
-      li= message
+    - if @rental&.errors.present?
+      ul#error_explanation.alert.alert-danger [style="list-style: none;"]
+        - @rental.errors.full_messages.each do |message|
+          li= message
 
-- unless @book.going_rental
-  = form_with url: rentals_path(book_id: @book.id), method: :post do |f|
-    .row
-      .col-6
-        = f.collection_select(:user_id, User.where(in_office: true).order(:furigana), :id, :name, {prompt: '借りる人を選択してください'}, {class: 'form-control form-control-lg input-sm mb-3'})
-      .col-1
-        = f.submit '借りる', class: 'btn btn-primary btn-lg mb-3'
-- else
-  = form_with url: rental_path(book_id: @book.id), method: :patch do |f|
-    = f.submit '返す', class: 'btn btn-success btn-lg mb-3'
+    - unless @book.going_rental
+      = form_with url: rentals_path(book_id: @book.id), method: :post do |f|
+        .row
+          .col-6
+            = f.collection_select(:user_id, User.where(in_office: true).order(:furigana), :id, :name, {prompt: '借りる人を選択してください'}, {class: 'form-control form-control-lg input-sm mb-3'})
+          .col-1
+            = f.submit '借りる', class: 'btn btn-primary btn-lg mb-3'
+    - else
+      = form_with url: rental_path(book_id: @book.id), method: :patch do |f|
+        = f.submit '返す', class: 'btn btn-success btn-lg mb-3'
 
 h2.mt-3 貸し出し履歴
 

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -7,7 +7,7 @@
 .row
   .col-2
     - if @book.image.attached?
-      image= image_tag @book.image.variant(resize:'257x364').processed, class: 'img-thumbnail float-start'
+      = image_tag @book.image.variant(resize:'257x364').processed, class: 'img-thumbnail float-start'
     - else
       img.img-thumbnail[src="https://placehold.jp/257x364.png?text=book image" alt="..."]
   .col-10

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,7 @@ ja:
       book:
         id: ID
         title: タイトル
+        image: 画像
       user:
         id: ID
         name: 名前

--- a/db/migrate/20220216050829_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220216050829_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_044140) do
+ActiveRecord::Schema.define(version: 2022_02_16_050829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title", limit: 50, null: false
@@ -39,6 +67,8 @@ ActiveRecord::Schema.define(version: 2022_02_14_044140) do
     t.boolean "in_office", default: true, null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "rentals", "books"
   add_foreign_key "rentals", "users"
 end


### PR DESCRIPTION
## 目的
ActiveStorageで画像の登録、表示をする
## 変更点
- Active Storageを導入
- bookモデルに画像の紐付けを追加
- 新規登録、編集画面に画像アップロード用フィールドを追加
<img width="1440" alt="スクリーンショット 2022-02-17 10 10 28" src="https://user-images.githubusercontent.com/95733683/154384851-d679d21c-5b99-43f5-928d-7b1dd329fdeb.png">

- imageの翻訳情報を追加
- コントローラで画像の登録を許可する
- Gem image_processingを導入
- imageを追加
<img width="1440" alt="スクリーンショット 2022-02-16 17 21 13" src="https://user-images.githubusercontent.com/95733683/154384973-0e1efa9f-c993-4800-a806-5e0c113c847f.png">

- 画面タイトルの位置を変更
<img width="1440" alt="スクリーンショット 2022-02-17 10 11 54" src="https://user-images.githubusercontent.com/95733683/154384995-5cb4e9bc-fb6d-408e-81f5-910d38e5e497.png">

画像が登録されてない場合
<img width="1440" alt="スクリーンショット 2022-02-17 10 12 33" src="https://user-images.githubusercontent.com/95733683/154385079-b36ac7a0-8864-4e7d-90a8-4a1032ff92fe.png">

## 注意点
close #89